### PR TITLE
Crash if player spawn back to Y coord. >0 & <1

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2657,7 +2657,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return bool|Position
 	 */
 	public function getSafeSpawn($spawn = null){
-		if(!($spawn instanceof Vector3) or $spawn->y <= 0){
+		if(!($spawn instanceof Vector3) or $spawn->y < 1){
 			$spawn = $this->getSpawnLocation();
 		}
 		if($spawn instanceof Vector3){


### PR DESCRIPTION
The issue come from  line 2664 : $v = $spawn->floor()  
If $spawn->y is in ]0..1[ then $v->y == 0
Then getBlockId : line 2670 use  'y' as -1 => Crash boom
