### PR TITLE
PR-bugfix : getSeed expect an int and not a string

### DIFF
--- a/src/pocketmine/level/format/generic/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/generic/BaseLevelProvider.php
@@ -88,7 +88,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	public function getSeed(){
-		return $this->levelData["RandomSeed"];
+		return intval( $this->levelData["RandomSeed"] );
 	}
 
 	public function setSeed($value){


### PR DESCRIPTION
**issue:**
crash dump with
Error: Return value of pocketmine\level\Level::getSeed() must be of the type integer, string returned
File: /src/pocketmine/level/Level
Line: 2708

**Fix:**
Update BaseLevelProvider.php  to  sure that getSeed() return an integer. 
